### PR TITLE
Add check for reused trasaction ids across client

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -13,3 +13,9 @@ impl ClientId {
 /// The input transaction id
 #[derive(Clone, Copy, Debug, Deserialize, Hash, Eq, PartialEq)]
 pub struct TxId(pub u32);
+
+impl TxId {
+    pub fn id(&self) -> u32 {
+        self.0
+    }
+}

--- a/test_suites/integration/error/duplicate_tx.csv
+++ b/test_suites/integration/error/duplicate_tx.csv
@@ -1,0 +1,1 @@
+Error: Reused transaction 1

--- a/test_suites/integration/input/duplicate_tx.csv
+++ b/test_suites/integration/input/duplicate_tx.csv
@@ -1,0 +1,3 @@
+type, client,tx, amount
+deposit, 1,1, 1.0
+deposit, 2, 1, 2


### PR DESCRIPTION
Transaction ids are globally unique so enforce it

Test Plan:

 ./run_suite.sh integration